### PR TITLE
AupDotNetを0.1.2に更新

### DIFF
--- a/AupRename/AupRename.csproj
+++ b/AupRename/AupRename.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Karoterra.AupDotNet" Version="0.1.0" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.1.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
patch.aul r43_ss_57 以降を導入した環境で作成したaupファイルでは画像ファイルがリネームできなくなっていた。
https://github.com/karoterra/AupDotNet/issues/3

その対策をAupDotNet側で行ったので更新する。
https://github.com/karoterra/AupDotNet/pull/5