### PR TITLE
PSDToolKitで表示しているPSDファイルのリネーム機能を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: .NET Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build project
+        run: dotnet build --configuration Release --no-restore
+
+      - name: Run tests
+        run: dotnet test --configuration Release --no-build --verbosity normal

--- a/AupRename.Tests/AupRename.Tests.csproj
+++ b/AupRename.Tests/AupRename.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AupRename\AupRename.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/AupRename.Tests/EncodingFixture.cs
+++ b/AupRename.Tests/EncodingFixture.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AupRename.Tests
+{
+    public class EncodingFixture
+    {
+        public EncodingFixture()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+    }
+}

--- a/AupRename.Tests/ExEditHelper.cs
+++ b/AupRename.Tests/ExEditHelper.cs
@@ -1,0 +1,25 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AupRename.Tests
+{
+    internal class ExEditHelper
+    {
+        public static TimelineObject CreateTimelineObject()
+        {
+            var data = new byte[0x5C8];
+            for (int i = 0; i < TimelineObject.MaxEffect; i++)
+            {
+                int typeIndex = -1;
+                typeIndex.ToBytes().CopyTo(data, 0x54 + i * 12);
+            }
+            List<EffectType> effectTypes = [];
+            return new TimelineObject(data, 0, effectTypes);
+        }
+    }
+}

--- a/AupRename.Tests/PsdToolKitProjectTest.cs
+++ b/AupRename.Tests/PsdToolKitProjectTest.cs
@@ -1,0 +1,33 @@
+﻿using Karoterra.AupDotNet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AupRename.Tests
+{
+    public class PsdToolKitProjectTest
+    {
+        [Fact]
+        public void Test_DumpData()
+        {
+            var json = string.Join("",
+                "[{",
+                "\"Image\":{",
+                    "\"Version\":1,",
+                    @"""FilePath"":""C:\\path\\to\\テスト.psd"",",
+                    "\"Layer\":{},",
+                    "\"PFV\":{\"Node\":null,\"FaviewNode\":null}",
+                "},",
+                "\"Tag\":676809393,",
+                "\"Thumbnail\":\"\"",
+                "}]\n"
+            );
+            var filter = new PsdToolKitProject(new RawFilterProject("PSDToolKit", Encoding.UTF8.GetBytes(json)));
+            var dumpedJson = Encoding.UTF8.GetString(filter.DumpData());
+            Assert.Single(filter.Images);
+            Assert.Equal(json, dumpedJson);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/AudioFileRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/AudioFileRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class AudioFileRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = AudioFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new AudioFileEffect
+            {
+                Filename = ""
+            };
+            var item = AudioFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new AudioFileEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = AudioFileRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new AudioFileEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = new AudioFileRenameItem(effect);
+            item.Rename("test_new.wav");
+            Assert.Equal("test_new.wav", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new AudioFileEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = new AudioFileRenameItem(effect);
+            item.Rename("test_new.wav");
+            item.Revert();
+            Assert.Equal("test.wav", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/BorderRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/BorderRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class BorderRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = BorderRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new BorderEffect
+            {
+                Filename = ""
+            };
+            var item = BorderRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new BorderEffect
+            {
+                Filename = "test.png"
+            };
+            var item = BorderRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new BorderEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new BorderRenameItem(effect);
+            item.Rename("test_new.png");
+            Assert.Equal("test_new.png", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new BorderEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new BorderRenameItem(effect);
+            item.Rename("test_new.png");
+            item.Revert();
+            Assert.Equal("test.png", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/DisplacementRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/DisplacementRenameItemTest.cs
@@ -1,0 +1,92 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class DisplacementRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = DisplacementRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_NameIsEmpty()
+        {
+            var effect = new DisplacementEffect
+            {
+                Name = "",
+            };
+            var item = DisplacementRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.BuiltIn, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new DisplacementEffect
+            {
+                Filename = "",
+            };
+            var item = DisplacementRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_Figure()
+        {
+            var effect = new DisplacementEffect
+            {
+                Name = "test",
+            };
+            var item = DisplacementRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.Figure, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_File()
+        {
+            var effect = new DisplacementEffect
+            {
+                Filename = @"C:\test.png",
+            };
+            var item = DisplacementRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new DisplacementEffect
+            {
+                Name = "test"
+            };
+            var item = new DisplacementRenameItem(effect);
+            item.Rename("test_new");
+            Assert.Equal("test_new", effect.Name);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new DisplacementEffect
+            {
+                Name = "test"
+            };
+            var item = new DisplacementRenameItem(effect);
+            item.Rename("test_new");
+            item.Revert();
+            Assert.Equal("test", effect.Name);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/FigureRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/FigureRenameItemTest.cs
@@ -1,0 +1,92 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class FigureRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = FigureRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_NameIsEmpty()
+        {
+            var effect = new FigureEffect
+            {
+                Name = "",
+            };
+            var item = FigureRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.BuiltIn, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new FigureEffect
+            {
+                Filename = "",
+            };
+            var item = FigureRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_Figure()
+        {
+            var effect = new FigureEffect
+            {
+                Name = "test",
+            };
+            var item = FigureRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.Figure, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_File()
+        {
+            var effect = new FigureEffect
+            {
+                Filename = @"C:\test.png",
+            };
+            var item = FigureRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new FigureEffect
+            {
+                Name = "test"
+            };
+            var item = new FigureRenameItem(effect);
+            item.Rename("test_new");
+            Assert.Equal("test_new", effect.Name);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new FigureEffect
+            {
+                Name = "test"
+            };
+            var item = new FigureRenameItem(effect);
+            item.Rename("test_new");
+            item.Revert();
+            Assert.Equal("test", effect.Name);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/ImageCompositionRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/ImageCompositionRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class ImageCompositionRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ImageCompositionRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new ImageCompositionEffect
+            {
+                Filename = ""
+            };
+            var item = ImageCompositionRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new ImageCompositionEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ImageCompositionRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new ImageCompositionEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ImageCompositionRenameItem(effect);
+            item.Rename("test_new.png");
+            Assert.Equal("test_new.png", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new ImageCompositionEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ImageCompositionRenameItem(effect);
+            item.Rename("test_new.png");
+            item.Revert();
+            Assert.Equal("test.png", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/ImageFileRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/ImageFileRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class ImageFileRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new VideoFileEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = ImageFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = ""
+            };
+            var item = ImageFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ImageFileRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ImageFileRenameItem(effect);
+            item.Rename("test_new.png");
+            Assert.Equal("test_new.png", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ImageFileRenameItem(effect);
+            item.Rename("test_new.png");
+            item.Revert();
+            Assert.Equal("test.png", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/MaskRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/MaskRenameItemTest.cs
@@ -1,0 +1,92 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class MaskRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = MaskRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_NameIsEmpty()
+        {
+            var effect = new MaskEffect
+            {
+                Name = "",
+            };
+            var item = MaskRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.BuiltIn, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new MaskEffect
+            {
+                Filename = "",
+            };
+            var item = MaskRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_Figure()
+        {
+            var effect = new MaskEffect
+            {
+                Name = "test",
+            };
+            var item = MaskRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.Figure, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_File()
+        {
+            var effect = new MaskEffect
+            {
+                Filename = @"C:\test.png",
+            };
+            var item = MaskRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new MaskEffect
+            {
+                Name = "test"
+            };
+            var item = new MaskRenameItem(effect);
+            item.Rename("test_new");
+            Assert.Equal("test_new", effect.Name);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new MaskEffect
+            {
+                Name = "test"
+            };
+            var item = new MaskRenameItem(effect);
+            item.Rename("test_new");
+            item.Revert();
+            Assert.Equal("test", effect.Name);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/PartialFilterRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/PartialFilterRenameItemTest.cs
@@ -1,0 +1,92 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class PartialFilterRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = PartialFilterRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_NameIsEmpty()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Name = "",
+            };
+            var item = PartialFilterRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.BuiltIn, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Filename = "",
+            };
+            var item = PartialFilterRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_Figure()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Name = "test",
+            };
+            var item = PartialFilterRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.Figure, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success_File()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Filename = @"C:\test.png",
+            };
+            var item = PartialFilterRenameItem.CreateIfTarget(effect);
+            Assert.Equal(FigureNameType.File, effect.NameType);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Name = "test"
+            };
+            var item = new PartialFilterRenameItem(effect);
+            item.Rename("test_new");
+            Assert.Equal("test_new", effect.Name);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new PartialFilterEffect
+            {
+                Name = "test"
+            };
+            var item = new PartialFilterRenameItem(effect);
+            item.Rename("test_new");
+            item.Revert();
+            Assert.Equal("test", effect.Name);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/PsdRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/PsdRenameItemTest.cs
@@ -1,0 +1,94 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class PsdRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_Rename()
+        {
+            var json = JArray.Parse("""
+                [
+                    {
+                        "Image": {
+                            "Version": 1,
+                            "FilePath": "C:\\path\\to\\テスト.psd",
+                            "Layer": {},
+                            "PFV": {"Node": null, "FaviewNode": null}
+                        },
+                        "Tag": 676809393,
+                        "Thumbnail": ""
+                    }
+                ]
+                """);
+            Assert.Equal(676809393, json[0]["Tag"]?.ToObject<int>());
+            Assert.Equal(@"C:\path\to\テスト.psd", json[0]["Image"]?["FilePath"]?.ToObject<string>());
+
+            var text = new TextEffect
+            {
+                Text = string.Join("\r\n",
+                    "<?-- テスト.psd ",
+                    "",
+                    "o={ -- オプション設定",
+                    "lipsync = 0    ,-- 口パク準備のレイヤー番号",
+                    "mpslider = 0    ,-- 多目的スライダーのレイヤー番号",
+                    "scene = 0    ,-- シーン番号",
+                    "tag = 676809393    ,-- 識別用タグ",
+                    "sendguard = 1    ,-- 「送る」誤送信保護",
+                    "",
+                    "-- 口パク準備のデフォルト設定",
+                    "ls_locut = 100    ,-- ローカット",
+                    "ls_hicut = 1000    ,-- ハイカット",
+                    "ls_threshold = 20    ,-- しきい値",
+                    "ls_sensitivity = 1    ,-- 感度",
+                    "",
+                    "-- 以下は書き換えないでください",
+                    @"ptkf=""C:\\path\\to\\テスト.psd"",ptkl=""""}PSD,subobj=require(""PSDToolKit"").PSDState.init(obj,o)?>"
+                )
+            };
+            var anm = new AnimationEffect
+            {
+                Name = "描画@PSD"
+            };
+            List<TimelineObject> objects = [ExEditHelper.CreateTimelineObject()];
+            objects[0].Effects.Add(text);
+            objects[0].Effects.Add(anm);
+
+            var item = new PsdRenameItem(json[0], objects);
+
+            item.Rename(@"C:\path\to\テスト_リネーム後.psd");
+
+            Assert.Equal(@"C:\path\to\テスト_リネーム後.psd", json[0]["Image"]?["FilePath"]);
+
+            Assert.Equal(string.Join("\r\n",
+                    "<?-- テスト_リネーム後.psd ",
+                    "",
+                    "o={ -- オプション設定",
+                    "lipsync = 0    ,-- 口パク準備のレイヤー番号",
+                    "mpslider = 0    ,-- 多目的スライダーのレイヤー番号",
+                    "scene = 0    ,-- シーン番号",
+                    "tag = 676809393    ,-- 識別用タグ",
+                    "sendguard = 1    ,-- 「送る」誤送信保護",
+                    "",
+                    "-- 口パク準備のデフォルト設定",
+                    "ls_locut = 100    ,-- ローカット",
+                    "ls_hicut = 1000    ,-- ハイカット",
+                    "ls_threshold = 20    ,-- しきい値",
+                    "ls_sensitivity = 1    ,-- 感度",
+                    "",
+                    "-- 以下は書き換えないでください",
+                    @"ptkf=""C:\\path\\to\\テスト_リネーム後.psd"",ptkl=""""}PSD,subobj=require(""PSDToolKit"").PSDState.init(obj,o)?>"
+                ),
+                text.Text
+            );
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/ScriptFileRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/ScriptFileRenameItemTest.cs
@@ -1,0 +1,117 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class ScriptFileRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ScriptFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_ParamsIsNull()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = null
+            };
+            var item = ScriptFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_ParamsIsEmpty()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = { }
+            };
+            var item = ScriptFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FileIsEmpty()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", "" } }
+            };
+            var item = ScriptFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", @"""C:\\test.txt""" } }
+            };
+            var item = ScriptFileRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_OldName()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", @"""C:\\test.txt""" } }
+            };
+            var item = new ScriptFileRenameItem(effect);
+            Assert.Equal(@"C:\test.txt", item.OldName);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", @"""C:\\test.txt""" } }
+            };
+            var item = new ScriptFileRenameItem(effect);
+            item.Rename(@"C:\test_new.txt");
+            Assert.Equal(@"""C:\\test_new.txt""", effect.Params?["file"]);
+        }
+
+        [Fact]
+        public void Test_Rename_MaxByteCountOfStringException()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", @"""C:\\test.txt""" } }
+            };
+            var item = new ScriptFileRenameItem(effect);
+            int charCount = ScriptFileEffect.MaxParamsLength
+                - 7     // file=""
+                - 4     // C:\\
+                - 4     // .txt
+                ;
+            string longPath = @"C:\" + new string('a', charCount) + ".txt";
+            Assert.Throws<MaxByteCountOfStringException>(() => item.Rename(longPath));
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new AnimationEffect
+            {
+                Params = new() { { "file", @"""C:\\test.txt""" } }
+            };
+            var item = new ScriptFileRenameItem(effect);
+            item.Rename(@"C:\test_new.txt");
+            item.Revert();
+            Assert.Equal(@"""C:\\test.txt""", effect.Params?["file"]);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/ShadowRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/ShadowRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class ShadowRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ShadowRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new ShadowEffect
+            {
+                Filename = ""
+            };
+            var item = ShadowRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new ShadowEffect
+            {
+                Filename = "test.png"
+            };
+            var item = ShadowRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new ShadowEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ShadowRenameItem(effect);
+            item.Rename("test_new.png");
+            Assert.Equal("test_new.png", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new ShadowEffect
+            {
+                Filename = "test.png"
+            };
+            var item = new ShadowRenameItem(effect);
+            item.Rename("test_new.png");
+            item.Revert();
+            Assert.Equal("test.png", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/VideoCompositionRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/VideoCompositionRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class VideoCompositionRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = VideoCompositionRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new VideoCompositionEffect
+            {
+                Filename = ""
+            };
+            var item = VideoCompositionRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new VideoCompositionEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = VideoCompositionRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new VideoCompositionEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = new VideoCompositionRenameItem(effect);
+            item.Rename("test_new.mp4");
+            Assert.Equal("test_new.mp4", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new VideoCompositionEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = new VideoCompositionRenameItem(effect);
+            item.Rename("test_new.mp4");
+            item.Revert();
+            Assert.Equal("test.mp4", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/VideoFileRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/VideoFileRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class VideoFileRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new AudioFileEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = VideoFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new VideoFileEffect
+            {
+                Filename = ""
+            };
+            var item = VideoFileRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new VideoFileEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = VideoFileRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new VideoFileEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = new VideoFileRenameItem(effect);
+            item.Rename("test_new.mp4");
+            Assert.Equal("test_new.mp4", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new VideoFileEffect
+            {
+                Filename = "test.mp4"
+            };
+            var item = new VideoFileRenameItem(effect);
+            item.Rename("test_new.mp4");
+            item.Revert();
+            Assert.Equal("test.mp4", effect.Filename);
+        }
+    }
+}

--- a/AupRename.Tests/RenameItems/WaveformRenameItemTest.cs
+++ b/AupRename.Tests/RenameItems/WaveformRenameItemTest.cs
@@ -1,0 +1,66 @@
+﻿using AupRename.RenameItems;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.Tests.RenameItems
+{
+    public class WaveformRenameItemTest : IClassFixture<EncodingFixture>
+    {
+        [Fact]
+        public void Test_CreateIfTarget_InvalidEffect()
+        {
+            var effect = new ImageFileEffect
+            {
+                Filename = "test.png"
+            };
+            var item = WaveformRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_FilenameIsEmpty()
+        {
+            var effect = new WaveformEffect
+            {
+                Filename = ""
+            };
+            var item = WaveformRenameItem.CreateIfTarget(effect);
+            Assert.Null(item);
+        }
+
+        [Fact]
+        public void Test_CreateIfTarget_Success()
+        {
+            var effect = new WaveformEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = WaveformRenameItem.CreateIfTarget(effect);
+            Assert.NotNull(item);
+        }
+
+        [Fact]
+        public void Test_Rename()
+        {
+            var effect = new WaveformEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = new WaveformRenameItem(effect);
+            item.Rename("test_new.wav");
+            Assert.Equal("test_new.wav", effect.Filename);
+        }
+
+        [Fact]
+        public void Test_Revert()
+        {
+            var effect = new WaveformEffect
+            {
+                Filename = "test.wav"
+            };
+            var item = new WaveformRenameItem(effect);
+            item.Rename("test_new.wav");
+            item.Revert();
+            Assert.Equal("test.wav", effect.Filename);
+        }
+    }
+}

--- a/AupRename.sln
+++ b/AupRename.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AupRename", "AupRename\AupRename.csproj", "{A2F6F108-5053-46E9-9900-CC70D3986CDE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AupRename.Tests", "AupRename.Tests\AupRename.Tests.csproj", "{F67479CC-9538-46EE-A8CF-4A87B4CE3F7F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{A2F6F108-5053-46E9-9900-CC70D3986CDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A2F6F108-5053-46E9-9900-CC70D3986CDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2F6F108-5053-46E9-9900-CC70D3986CDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F67479CC-9538-46EE-A8CF-4A87B4CE3F7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F67479CC-9538-46EE-A8CF-4A87B4CE3F7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F67479CC-9538-46EE-A8CF-4A87B4CE3F7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F67479CC-9538-46EE-A8CF-4A87B4CE3F7F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AupRename/App.config
+++ b/AupRename/App.config
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+        <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
+            <section name="AupRename.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
+    <userSettings>
+        <AupRename.Properties.Settings>
+            <setting name="Editor" serializeAs="String">
+                <value>notepad.exe</value>
+            </setting>
+            <setting name="EnableVideo" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableImage" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableAudio" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableWaveform" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableShadow" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableBorder" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableVideoComposition" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableImageComposition" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableFigure" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableMask" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableDisplacement" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnablePartialFilter" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="EnableScript" serializeAs="String">
+                <value>True</value>
+            </setting>
+            <setting name="IsUpgrade" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="EnablePsdToolKit" serializeAs="String">
+                <value>True</value>
+            </setting>
+        </AupRename.Properties.Settings>
+    </userSettings>
+</configuration>

--- a/AupRename/AupRename.csproj
+++ b/AupRename/AupRename.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AupRename/AupRename.csproj
+++ b/AupRename/AupRename.csproj
@@ -7,6 +7,7 @@
     <Version>0.3.0</Version>
     <Authors>karoterra</Authors>
     <Copyright>Copyright © 2021 karoterra</Copyright>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AupRename/DelegateCommand.cs
+++ b/AupRename/DelegateCommand.cs
@@ -6,27 +6,27 @@ namespace AupRename
     public class DelegateCommand : ICommand
     {
         private readonly Action _execute;
-        private readonly Func<bool> _canExecute;
+        private readonly Func<bool>? _canExecute;
 
-        public event EventHandler CanExecuteChanged;
+        public event EventHandler? CanExecuteChanged;
 
         public DelegateCommand(Action execute)
             : this(execute, null)
         {
         }
 
-        public DelegateCommand(Action execute, Func<bool> canExecute)
+        public DelegateCommand(Action execute, Func<bool>? canExecute)
         {
             _execute = execute ?? throw new ArgumentException(null, nameof(execute));
             _canExecute = canExecute;
         }
 
-        public bool CanExecute(object parameter)
+        public bool CanExecute(object? parameter)
         {
             return _canExecute == null || _canExecute();
         }
 
-        public void Execute(object parameter)
+        public void Execute(object? parameter)
         {
             _execute();
         }

--- a/AupRename/MainViewModel.cs
+++ b/AupRename/MainViewModel.cs
@@ -12,7 +12,7 @@ namespace AupRename
     {
         private const string Url = "https://github.com/karoterra/AupRename";
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
         public readonly Renamer Renamer;
 
         public DelegateCommand OpenFileCommand { get; init; }
@@ -178,14 +178,6 @@ namespace AupRename
             Renamer = new Renamer();
             OpenFileCommand = new DelegateCommand(OpenFile);
             ReferEditorCommand = new DelegateCommand(ReferEditor);
-            NewEditCommand = new DelegateCommand(() =>
-            {
-                Renamer.NewEdit();
-                RaisePropertyChanged(nameof(Status));
-                ReEditCommand.RaiseCanExecuteChanged();
-                ApplyCommand.RaiseCanExecuteChanged();
-                RevertCommand.RaiseCanExecuteChanged();
-            });
             ReEditCommand = new DelegateCommand(
                 () => { Renamer.ReEdit(); RaisePropertyChanged(nameof(Status)); },
                 () => Renamer.IsEditing);
@@ -195,6 +187,14 @@ namespace AupRename
             RevertCommand = new DelegateCommand(
                 () => { Renamer.Revert(); RaisePropertyChanged(nameof(Status)); },
                 () => Renamer.IsEditing);
+            NewEditCommand = new DelegateCommand(() =>
+            {
+                Renamer.NewEdit();
+                RaisePropertyChanged(nameof(Status));
+                ReEditCommand.RaiseCanExecuteChanged();
+                ApplyCommand.RaiseCanExecuteChanged();
+                RevertCommand.RaiseCanExecuteChanged();
+            });
             OpenUrlCommand = new DelegateCommand(OpenUrl);
             ShowVersionCommand = new DelegateCommand(ShowVersion);
             ShutdownCommand = new DelegateCommand(Shutdown);
@@ -286,7 +286,7 @@ namespace AupRename
             Properties.Settings.Default.Save();
         }
 
-        private void RaisePropertyChanged([CallerMemberName] string name = null)
+        private void RaisePropertyChanged([CallerMemberName] string? name = null)
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
         }

--- a/AupRename/MainViewModel.cs
+++ b/AupRename/MainViewModel.cs
@@ -163,6 +163,16 @@ namespace AupRename
             }
         }
 
+        public bool EnablePsdToolKit
+        {
+            get => Renamer.EnablePsdToolKit;
+            set
+            {
+                Renamer.EnablePsdToolKit = value;
+                RaisePropertyChanged();
+            }
+        }
+
         public string Status
         {
             get => Renamer.Status;
@@ -265,6 +275,7 @@ namespace AupRename
             EnableDisplacement = Properties.Settings.Default.EnableDisplacement;
             EnablePartialFilter = Properties.Settings.Default.EnablePartialFilter;
             EnableScript = Properties.Settings.Default.EnableScript;
+            EnablePsdToolKit = Properties.Settings.Default.EnablePsdToolKit;
         }
 
         public void SaveSetting()
@@ -283,6 +294,7 @@ namespace AupRename
             Properties.Settings.Default.EnableDisplacement = EnableDisplacement;
             Properties.Settings.Default.EnablePartialFilter = EnablePartialFilter;
             Properties.Settings.Default.EnableScript = EnableScript;
+            Properties.Settings.Default.EnablePsdToolKit = EnablePsdToolKit;
             Properties.Settings.Default.Save();
         }
 

--- a/AupRename/MainWindow.xaml
+++ b/AupRename/MainWindow.xaml
@@ -71,6 +71,8 @@
                         <CheckBox Content="部分フィルタ" Margin="0,5,0,0" IsChecked="{Binding EnablePartialFilter}"/>
                         <Separator Margin="0,7,0,2"/>
                         <CheckBox Content="スクリプト" Margin="0,5,0,0" IsChecked="{Binding EnableScript}"/>
+                        <Separator Margin="0,7,0,2"/>
+                        <CheckBox Content="PSDToolKit" Margin="0,5,0,0" IsChecked="{Binding EnablePsdToolKit}"/>
                     </StackPanel>
                 </Grid>
             </GroupBox>

--- a/AupRename/Properties/Settings.Designer.cs
+++ b/AupRename/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace AupRename.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -200,6 +200,18 @@ namespace AupRename.Properties {
             }
             set {
                 this["IsUpgrade"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool EnablePsdToolKit {
+            get {
+                return ((bool)(this["EnablePsdToolKit"]));
+            }
+            set {
+                this["EnablePsdToolKit"] = value;
             }
         }
     }

--- a/AupRename/Properties/Settings.settings
+++ b/AupRename/Properties/Settings.settings
@@ -47,5 +47,8 @@
     <Setting Name="IsUpgrade" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="EnablePsdToolKit" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/AupRename/PsdToolKitProject.cs
+++ b/AupRename/PsdToolKitProject.cs
@@ -1,0 +1,25 @@
+﻿using System.Text;
+using Karoterra.AupDotNet;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace AupRename
+{
+    public class PsdToolKitProject : FilterProject
+    {
+        public JArray Images { get; }
+
+        public PsdToolKitProject(FilterProject filter)
+        {
+            Name = "PSDToolKit";
+            string jsonStr = Encoding.UTF8.GetString(filter.DumpData());
+            Images = JArray.Parse(jsonStr);
+        }
+
+        public override byte[] DumpData()
+        {
+            string jsonStr = JsonConvert.SerializeObject(Images) + "\n";
+            return Encoding.UTF8.GetBytes(jsonStr);
+        }
+    }
+}

--- a/AupRename/RenameItem.cs
+++ b/AupRename/RenameItem.cs
@@ -4,6 +4,6 @@
     {
         public int ObjectIndex;
         public int EffectIndex;
-        public string Filename;
+        public string Filename = "";
     }
 }

--- a/AupRename/RenameItem.cs
+++ b/AupRename/RenameItem.cs
@@ -1,9 +1,0 @@
-﻿namespace AupRename
-{
-    class RenameItem
-    {
-        public int ObjectIndex;
-        public int EffectIndex;
-        public string Filename = "";
-    }
-}

--- a/AupRename/RenameItems/AudioFileRenameItem.cs
+++ b/AupRename/RenameItems/AudioFileRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class AudioFileRenameItem(AudioFileEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly AudioFileEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static AudioFileRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is AudioFileEffect audio && !string.IsNullOrEmpty(audio.Filename))
+            {
+                return new AudioFileRenameItem(audio);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/BorderRenameItem.cs
+++ b/AupRename/RenameItems/BorderRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class BorderRenameItem(BorderEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly BorderEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static BorderRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is BorderEffect border && !string.IsNullOrEmpty(border.Filename))
+            {
+                return new BorderRenameItem(border);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/DisplacementRenameItem.cs
+++ b/AupRename/RenameItems/DisplacementRenameItem.cs
@@ -1,0 +1,37 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class DisplacementRenameItem(DisplacementEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Name;
+        public string OldName => _oldName;
+
+        private readonly DisplacementEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Name = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Name = _oldName;
+        }
+
+        public static DisplacementRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is DisplacementEffect disp
+                && (
+                    (disp.NameType == FigureNameType.File && !string.IsNullOrEmpty(disp.Filename))
+                    || disp.NameType == FigureNameType.Figure
+                )
+            )
+            {
+                return new DisplacementRenameItem(disp);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/FigureRenameItem.cs
+++ b/AupRename/RenameItems/FigureRenameItem.cs
@@ -1,0 +1,37 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class FigureRenameItem(FigureEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Name;
+        public string OldName => _oldName;
+
+        private readonly FigureEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Name = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Name = _oldName;
+        }
+
+        public static FigureRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is FigureEffect figure
+                && (
+                    (figure.NameType == FigureNameType.File && !string.IsNullOrEmpty(figure.Filename))
+                    || figure.NameType == FigureNameType.Figure
+                )
+            )
+            {
+                return new FigureRenameItem(figure);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/IRenameItem.cs
+++ b/AupRename/RenameItems/IRenameItem.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AupRename.RenameItems
+{
+    public interface IRenameItem
+    {
+        // リネーム前の名前
+        string OldName { get; }
+
+        // リネーム実行
+        void Rename(string newName);
+
+        // 元に戻す
+        void Revert();
+    }
+}

--- a/AupRename/RenameItems/ImageCompositionRenameItem.cs
+++ b/AupRename/RenameItems/ImageCompositionRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class ImageCompositionRenameItem(ImageCompositionEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly ImageCompositionEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static ImageCompositionRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is ImageCompositionEffect image && !string.IsNullOrEmpty(image.Filename))
+            {
+                return new ImageCompositionRenameItem(image);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/ImageFileRenameItem.cs
+++ b/AupRename/RenameItems/ImageFileRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class ImageFileRenameItem(ImageFileEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly ImageFileEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static ImageFileRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is ImageFileEffect image && !string.IsNullOrEmpty(image.Filename))
+            {
+                return new ImageFileRenameItem(image);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/MaskRenameItem.cs
+++ b/AupRename/RenameItems/MaskRenameItem.cs
@@ -1,0 +1,37 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class MaskRenameItem(MaskEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Name;
+        public string OldName => _oldName;
+
+        private readonly MaskEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Name = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Name = _oldName;
+        }
+
+        public static MaskRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is MaskEffect mask
+                && (
+                    (mask.NameType == FigureNameType.File && !string.IsNullOrEmpty(mask.Filename))
+                    || mask.NameType == FigureNameType.Figure
+                )
+            )
+            {
+                return new MaskRenameItem(mask);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/PartialFilterRenameItem.cs
+++ b/AupRename/RenameItems/PartialFilterRenameItem.cs
@@ -1,0 +1,37 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class PartialFilterRenameItem(PartialFilterEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Name;
+        public string OldName => _oldName;
+
+        private readonly PartialFilterEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Name = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Name = _oldName;
+        }
+
+        public static PartialFilterRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is PartialFilterEffect pf
+                && (
+                    (pf.NameType == FigureNameType.File && !string.IsNullOrEmpty(pf.Filename))
+                    || pf.NameType == FigureNameType.Figure
+                )
+            )
+            {
+                return new PartialFilterRenameItem(pf);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/PsdRenameItem.cs
+++ b/AupRename/RenameItems/PsdRenameItem.cs
@@ -1,0 +1,90 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace AupRename.RenameItems
+{
+    public partial class PsdRenameItem : IRenameItem
+    {
+        public string OldName { get; }
+
+        public JToken PsdImage { get; }
+        private readonly JToken _image;
+        public int Tag { get; }
+
+        public List<TextEffect> Texts { get; } = [];
+        public List<string> OldTexts { get; } = [];
+
+        [GeneratedRegex(@"tag\s*=\s*(\d+)")]
+        private static partial Regex _regTag();
+
+        [GeneratedRegex(@"ptkf\s*=\s*""([^""]+)""")]
+        private static partial Regex _regPtkf();
+
+        [GeneratedRegex(@"<\?--.*\r?\n")]
+        private static partial Regex _regFilenameComment();
+
+        public PsdRenameItem(JToken psdImage, List<TimelineObject> objects)
+        {
+            PsdImage = psdImage;
+            var image = psdImage["Image"];
+            if (image == null)
+            {
+                throw new ArgumentException("Imageが見つかりませんでした", nameof(psdImage));
+            }
+            _image = image;
+            var tag = psdImage["Tag"];
+            if (tag == null)
+            {
+                throw new ArgumentException("Tagが見つかりませんでした", nameof(psdImage));
+            }
+            Tag = tag.ToObject<int>();
+            var tagStr = Tag.ToString();
+
+            OldName = _image["FilePath"]?.ToObject<string>() ?? "";
+            foreach (var obj in objects)
+            {
+                bool hasPsd = obj.Effects.Any(x => x is AnimationEffect anm && anm.Name == "描画@PSD");
+                if (hasPsd && obj.Effects.Count > 0 && obj.Effects[0] is TextEffect text)
+                {
+                    var tagMatch = _regTag().Match(text.Text);
+                    if (!tagMatch.Success || tagMatch.Groups[1].Value != tagStr)
+                    {
+                        continue;
+                    }
+                    Texts.Add(text);
+                    OldTexts.Add(text.Text);
+                }
+            }
+        }
+
+        public void Rename(string newName)
+        {
+            _image["FilePath"] = newName;
+
+            var escapedNewName = newName.Replace(@"\", @"\\");
+            var newFilename = Path.GetFileName(newName);
+            foreach (var text in Texts)
+            {
+                string newText = _regPtkf().Replace(text.Text, $@"ptkf=""{escapedNewName}""");
+                newText = _regFilenameComment().Replace(newText, $"<?-- {newFilename} \r\n");
+                text.Text = newText;
+            }
+        }
+
+        public void Revert()
+        {
+            _image["FilePath"] = OldName;
+
+            foreach (var (text, old) in Texts.Zip(OldTexts))
+            {
+                text.Text = old;
+            }
+        }
+    }
+}

--- a/AupRename/RenameItems/ScriptFileRenameItem.cs
+++ b/AupRename/RenameItems/ScriptFileRenameItem.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using Karoterra.AupDotNet;
+using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+using Karoterra.AupDotNet.Extensions;
+
+namespace AupRename.RenameItems
+{
+    public class ScriptFileRenameItem(ScriptFileEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Params?["file"][1..^1].Replace(@"\\", @"\") ?? "";
+        public string OldName => _oldName;
+
+        private readonly ScriptFileEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            if (_effect.Params == null) return;
+            _effect.Params["file"] = '"' + newName.Replace(@"\", @"\\") + '"';
+            if (_effect.BuildParams().GetSjisByteCount() >= ScriptFileEffect.MaxParamsLength)
+            {
+                throw new MaxByteCountOfStringException();
+            }
+        }
+
+        public void Revert()
+        {
+            Rename(_oldName);
+        }
+
+        public static ScriptFileRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (
+                effect is ScriptFileEffect script
+                && !string.IsNullOrEmpty(script.Params?.GetValueOrDefault("file"))
+            )
+            {
+                return new ScriptFileRenameItem(script);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/ShadowRenameItem.cs
+++ b/AupRename/RenameItems/ShadowRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class ShadowRenameItem(ShadowEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly ShadowEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static ShadowRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is ShadowEffect shadow && !string.IsNullOrEmpty(shadow.Filename))
+            {
+                return new ShadowRenameItem(shadow);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/VideoCompositionRenameItem.cs
+++ b/AupRename/RenameItems/VideoCompositionRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class VideoCompositionRenameItem(VideoCompositionEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly VideoCompositionEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static VideoCompositionRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is VideoCompositionEffect video && !string.IsNullOrEmpty(video.Filename))
+            {
+                return new VideoCompositionRenameItem(video);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/VideoFileRenameItem.cs
+++ b/AupRename/RenameItems/VideoFileRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class VideoFileRenameItem(VideoFileEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly VideoFileEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static VideoFileRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is VideoFileEffect video && !string.IsNullOrEmpty(video.Filename))
+            {
+                return new VideoFileRenameItem(video);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/RenameItems/WaveformRenameItem.cs
+++ b/AupRename/RenameItems/WaveformRenameItem.cs
@@ -1,0 +1,32 @@
+﻿using Karoterra.AupDotNet.ExEdit;
+using Karoterra.AupDotNet.ExEdit.Effects;
+
+namespace AupRename.RenameItems
+{
+    public class WaveformRenameItem(WaveformEffect effect) : IRenameItem
+    {
+        private readonly string _oldName = effect.Filename;
+        public string OldName => _oldName;
+
+        private readonly WaveformEffect _effect = effect;
+
+        public void Rename(string newName)
+        {
+            _effect.Filename = newName;
+        }
+
+        public void Revert()
+        {
+            _effect.Filename = _oldName;
+        }
+
+        public static WaveformRenameItem? CreateIfTarget(Effect effect)
+        {
+            if (effect is WaveformEffect wave && !string.IsNullOrEmpty(wave.Filename))
+            {
+                return new WaveformRenameItem(wave);
+            }
+            return null;
+        }
+    }
+}

--- a/AupRename/Renamer.cs
+++ b/AupRename/Renamer.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using AupRename.RenameItems;
 using Karoterra.AupDotNet;
 using Karoterra.AupDotNet.ExEdit;
 using Karoterra.AupDotNet.ExEdit.Effects;
@@ -40,7 +41,7 @@ namespace AupRename
         private string CurrentFilename = "";
         private AviUtlProject? _aup;
         private ExEditProject? _exedit;
-        private readonly List<RenameItem> _renameItems = [];
+        private readonly List<IRenameItem> _renameItems = [];
 
         private void OpenEditor()
         {
@@ -134,63 +135,58 @@ namespace AupRename
                 for (int effectIdx = 0; effectIdx < obj.Effects.Count; effectIdx++)
                 {
                     var effect = obj.Effects[effectIdx];
-                    if (EnableVideo && effect is VideoFileEffect video && !string.IsNullOrEmpty(video.Filename))
+                    IRenameItem? renameItem = null;
+                    if(EnableVideo && (renameItem = VideoFileRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = video.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableImage && effect is ImageFileEffect image && !string.IsNullOrEmpty(image.Filename))
+                    else if (EnableImage && (renameItem = ImageFileRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = image.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableAudio && effect is AudioFileEffect audio && !string.IsNullOrEmpty(audio.Filename))
+                    else if (EnableAudio && (renameItem = AudioFileRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = audio.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableWaveform && effect is WaveformEffect waveform && !string.IsNullOrEmpty(waveform.Filename))
+                    else if (EnableWaveform && (renameItem = WaveformRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = waveform.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableShadow && effect is ShadowEffect shadow && !string.IsNullOrEmpty(shadow.Filename))
+                    else if (EnableShadow && (renameItem = ShadowRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = shadow.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableBorder && effect is BorderEffect border && !string.IsNullOrEmpty(border.Filename))
+                    else if (EnableBorder && (renameItem = BorderRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = border.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableVideoComposition && effect is VideoCompositionEffect videoComp && !string.IsNullOrEmpty(videoComp.Filename))
+                    else if (EnableVideoComposition && (renameItem = VideoCompositionRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = videoComp.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableImageComposition && effect is ImageCompositionEffect imageComp && !string.IsNullOrEmpty(imageComp.Filename))
+                    else if (EnableImageComposition && (renameItem = ImageCompositionRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = imageComp.Filename });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableFigure && effect is FigureEffect figure &&
-                        ((figure.NameType == FigureNameType.File && !string.IsNullOrEmpty(figure.Filename)) || figure.NameType == FigureNameType.Figure))
+                    else if (EnableFigure && (renameItem = FigureRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = figure.Name });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableMask && effect is MaskEffect mask &&
-                        ((mask.NameType == FigureNameType.File && !string.IsNullOrEmpty(mask.Filename)) || mask.NameType == FigureNameType.Figure))
+                    else if (EnableMask && (renameItem = MaskRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = mask.Name });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableDisplacement && effect is DisplacementEffect displacement &&
-                        ((displacement.NameType == FigureNameType.File && !string.IsNullOrEmpty(displacement.Filename)) || displacement.NameType == FigureNameType.Figure))
+                    else if (EnableDisplacement && (renameItem = DisplacementRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = displacement.Name });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnablePartialFilter && effect is PartialFilterEffect pf &&
-                        ((pf.NameType == FigureNameType.File && !string.IsNullOrEmpty(pf.Filename)) || pf.NameType == FigureNameType.Figure))
+                    else if (EnablePartialFilter && (renameItem = PartialFilterRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = pf.Name });
+                        _renameItems.Add(renameItem);
                     }
-                    else if (EnableScript && effect is ScriptFileEffect script && !string.IsNullOrEmpty(script.Params?.GetValueOrDefault("file")))
+                    else if (EnableScript && (renameItem = ScriptFileRenameItem.CreateIfTarget(effect)) != null)
                     {
-                        var filename = script.Params["file"];
-                        filename = filename[1..^1].Replace(@"\\", @"\");
-                        _renameItems.Add(new RenameItem() { ObjectIndex = objIdx, EffectIndex = effectIdx, Filename = filename });
+                        _renameItems.Add(renameItem);
                     }
                 }
             }
@@ -208,7 +204,7 @@ namespace AupRename
                 using StreamWriter sw = new(ListFilename, false, Encoding.UTF8);
                 foreach (var item in _renameItems)
                 {
-                    sw.WriteLine(item.Filename);
+                    sw.WriteLine(item.OldName);
                 }
             }
             catch (IOException)
@@ -243,58 +239,9 @@ namespace AupRename
 
             for (int i = 0; i < _renameItems.Count; i++)
             {
-                var effect = _exedit.Objects[_renameItems[i].ObjectIndex].Effects[_renameItems[i].EffectIndex];
                 try
                 {
-                    switch (effect)
-                    {
-                        case VideoFileEffect video:
-                            video.Filename = newNames[i];
-                            break;
-                        case ImageFileEffect image:
-                            image.Filename = newNames[i];
-                            break;
-                        case AudioFileEffect audio:
-                            audio.Filename = newNames[i];
-                            break;
-                        case WaveformEffect waveform:
-                            waveform.Filename = newNames[i];
-                            break;
-                        case ShadowEffect shadow:
-                            shadow.Filename = newNames[i];
-                            break;
-                        case BorderEffect border:
-                            border.Filename = newNames[i];
-                            break;
-                        case VideoCompositionEffect video:
-                            video.Filename = newNames[i];
-                            break;
-                        case ImageCompositionEffect image:
-                            image.Filename = newNames[i];
-                            break;
-                        case FigureEffect figure:
-                            figure.Name = newNames[i];
-                            break;
-                        case MaskEffect mask:
-                            mask.Name = newNames[i];
-                            break;
-                        case DisplacementEffect d:
-                            d.Name = newNames[i];
-                            break;
-                        case PartialFilterEffect pf:
-                            pf.Name = newNames[i];
-                            break;
-                        case ScriptFileEffect script:
-                            if (script.Params != null)
-                            {
-                                script.Params["file"] = '"' + newNames[i].Replace(@"\", @"\\") + '"';
-                                if (script.BuildParams().GetSjisByteCount() >= ScriptFileEffect.MaxParamsLength)
-                                {
-                                    throw new MaxByteCountOfStringException();
-                                }
-                            }
-                            break;
-                    }
+                    _renameItems[i].Rename(newNames[i]);
                 }
                 catch (MaxByteCountOfStringException)
                 {
@@ -366,14 +313,35 @@ namespace AupRename
 
         public void Revert()
         {
-            if (_renameItems.Count == 0)
+            if (_aup == null || _renameItems.Count == 0)
             {
                 ShowError("ファイルを指定して新規編集してください。");
                 return;
             }
 
-            var newNames = _renameItems.Select(item => item.Filename).ToList();
-            Rename(newNames);
+            foreach (var item in _renameItems)
+            {
+                item.Revert();
+            }
+
+            try
+            {
+                using BinaryWriter writer = new(File.Create(CurrentFilename));
+                _aup.Write(writer);
+            }
+            catch (IOException)
+            {
+                ShowError("書き込みに失敗しました。");
+                return;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                ShowError("書き込みに失敗しました。");
+                return;
+            }
+
+            ShowInfo("変更を元に戻しました。");
+            Status = $"{Path.GetFileName(CurrentFilename)} の変更をリセット";
         }
 
         private static void ShowError(string message)

--- a/AupRename/Renamer.cs
+++ b/AupRename/Renamer.cs
@@ -33,6 +33,7 @@ namespace AupRename
         public bool EnableDisplacement { get; set; }
         public bool EnablePartialFilter { get; set; }
         public bool EnableScript { get; set; }
+        public bool EnablePsdToolKit { get; set; }
 
         public string Status { get; set; } = "";
 
@@ -41,6 +42,7 @@ namespace AupRename
         private string CurrentFilename = "";
         private AviUtlProject? _aup;
         private ExEditProject? _exedit;
+        private PsdToolKitProject? _psdToolKit;
         private readonly List<IRenameItem> _renameItems = [];
 
         private void OpenEditor()
@@ -67,6 +69,7 @@ namespace AupRename
             CurrentFilename = Filename;
             _aup = null;
             _exedit = null;
+            _psdToolKit = null;
             _renameItems.Clear();
             Status = "";
 
@@ -98,6 +101,7 @@ namespace AupRename
             }
 
             _exedit = null;
+            _psdToolKit = null;
             try
             {
                 for (int i = 0; i < _aup.FilterProjects.Count; i++)
@@ -106,7 +110,11 @@ namespace AupRename
                     {
                         _exedit = new ExEditProject(filter);
                         _aup.FilterProjects[i] = _exedit;
-                        break;
+                    }
+                    if (_aup.FilterProjects[i].Name == "PSDToolKit")
+                    {
+                        _psdToolKit = new PsdToolKitProject(_aup.FilterProjects[i]);
+                        _aup.FilterProjects[i] = _psdToolKit;
                     }
                 }
             }
@@ -127,6 +135,7 @@ namespace AupRename
             }
 
             _renameItems.Clear();
+            // 拡張編集
             for (int objIdx = 0; objIdx < _exedit.Objects.Count; objIdx++)
             {
                 var obj = _exedit.Objects[objIdx];
@@ -188,6 +197,14 @@ namespace AupRename
                     {
                         _renameItems.Add(renameItem);
                     }
+                }
+            }
+            // PSDToolKit
+            if (_psdToolKit != null && EnablePsdToolKit)
+            {
+                foreach (var psdImage in _psdToolKit.Images)
+                {
+                    _renameItems.Add(new PsdRenameItem(psdImage, _exedit.Objects));
                 }
             }
 

--- a/AupRename/VersionWindow.xaml.cs
+++ b/AupRename/VersionWindow.xaml.cs
@@ -27,9 +27,9 @@ namespace AupRename
             Assembly assem = Assembly.GetExecutingAssembly();
             var assemName = assem.GetName();
             nameLabel.Content = assemName.Name;
-            var version = assemName.Version;
+            Version version = assemName.Version ?? new Version(0, 0, 0);
             versionLabel.Content = $"Version {version.Major}.{version.Minor}.{version.Build}";
-            copyrightLabel.Content = assem.GetCustomAttribute<AssemblyCopyrightAttribute>().Copyright;
+            copyrightLabel.Content = assem.GetCustomAttribute<AssemblyCopyrightAttribute>()?.Copyright;
         }
 
         private void okButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Issue #10 の対応
PSDToolKitで表示しているPSDファイルのリネーム（参照パスの変更）機能を追加した。
機能追加にあたりリファクタリングを実施した。
テスト用のプロジェクトを追加し、GitHub Actionsでテストを実行できるように設定を追加した。