### PR TITLE
:sparkles: 拡張編集 (English mod) 対応を追加

### DIFF
--- a/AupRename/EnglishExEditProject.cs
+++ b/AupRename/EnglishExEditProject.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Karoterra.AupDotNet;
+using Karoterra.AupDotNet.ExEdit;
+
+namespace AupRename
+{
+    /// <summary>
+    /// 英語版拡張編集に対応するためのクラス
+    /// </summary>
+    public class EnglishExEditProject : ExEditProject
+    {
+        public EnglishExEditProject(RawFilterProject rawFilter, IEffectFactory? effectFactory = null) : base(rawFilter, effectFactory)
+        {
+            Name = "Advanced Editing";
+        }
+    }
+}

--- a/AupRename/Renamer.cs
+++ b/AupRename/Renamer.cs
@@ -106,10 +106,18 @@ namespace AupRename
             {
                 for (int i = 0; i < _aup.FilterProjects.Count; i++)
                 {
-                    if (_aup.FilterProjects[i] is RawFilterProject filter && filter.Name == "拡張編集")
+                    if (_aup.FilterProjects[i] is RawFilterProject filter)
                     {
-                        _exedit = new ExEditProject(filter);
-                        _aup.FilterProjects[i] = _exedit;
+                        if (filter.Name == "拡張編集")
+                        {
+                            _exedit = new ExEditProject(filter);
+                            _aup.FilterProjects[i] = _exedit;
+                        }
+                        else if (filter.Name == "Advanced Editing")
+                        {
+                            _exedit = new EnglishExEditProject(filter);
+                            _aup.FilterProjects[i] = _exedit;
+                        }
                     }
                     if (_aup.FilterProjects[i].Name == "PSDToolKit")
                     {


### PR DESCRIPTION
拡張編集 (English mod) 対応を追加 (#12)
拡張編集 (English mod) について、オリジナルの拡張編集を使ったときとのaupファイルの違いを確認したところ以下が見つかった。

- `FilterProject.Name` が `"拡張編集"` ではなく `"Advanced Editing"` になる
- `EffectType.Name` がそれぞれ英語になる

これまでの AupRename だと `FilterProject.Name` が `"拡張編集"` のものしか探していないので `"Advanced Editing"` も探すようにした。

`EffectType.Name` についてはaupファイルに保存されていたものをリネーム後も維持するので対応不要。
